### PR TITLE
Feature/#3 공통 예외처리 및 responseDto 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/sopt/sopt36goodoc/global/domain/BaseEntity.java
+++ b/src/main/java/sopt/sopt36goodoc/global/domain/BaseEntity.java
@@ -1,0 +1,22 @@
+package sopt.sopt36goodoc.global.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/sopt/sopt36goodoc/global/dto/ResponseDto.java
+++ b/src/main/java/sopt/sopt36goodoc/global/dto/ResponseDto.java
@@ -1,0 +1,45 @@
+package sopt.sopt36goodoc.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import sopt.sopt36goodoc.global.exception.ErrorCode;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"statusCode","errorCode", "message", "data"})
+public class ResponseDto<T> {
+    private final int statusCode;
+    private final String errorCode;
+    private final String message;
+    private T data;
+
+    public static <T> ResponseDto<T> success(final String message, final T data) {
+        return new ResponseDto<>(HttpStatus.OK.value(), null, message, data);
+    }
+
+    public static <T> ResponseDto<T> created(final String message, final T data) {
+        return new ResponseDto<>(HttpStatus.CREATED.value(), null, message, data);
+    }
+
+    public static <T> ResponseDto<T> fail(ErrorCode code) {
+        return new ResponseDto<>(
+                code.getStatus().value(),
+                code.getErrorCode(),
+                code.getMessage(),
+                null
+        );
+    }
+
+    public static <T> ResponseDto<T> fail(ErrorCode code, String message) {
+        return new ResponseDto<>(
+                code.getStatus().value(),
+                code.getErrorCode(),
+                message,
+                null
+        );
+    }
+}

--- a/src/main/java/sopt/sopt36goodoc/global/exception/CommonException.java
+++ b/src/main/java/sopt/sopt36goodoc/global/exception/CommonException.java
@@ -1,0 +1,13 @@
+package sopt.sopt36goodoc.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CommonException extends RuntimeException{
+    private final ErrorCode code;
+
+    public CommonException(ErrorCode code) {
+        super(code.getMessage());
+        this.code = code;
+    }
+}

--- a/src/main/java/sopt/sopt36goodoc/global/exception/CustomException.java
+++ b/src/main/java/sopt/sopt36goodoc/global/exception/CustomException.java
@@ -3,10 +3,10 @@ package sopt.sopt36goodoc.global.exception;
 import lombok.Getter;
 
 @Getter
-public class CommonException extends RuntimeException{
+public abstract class CustomException extends RuntimeException {
     private final ErrorCode code;
 
-    public CommonException(ErrorCode code) {
+    public CustomException(ErrorCode code) {
         super(code.getMessage());
         this.code = code;
     }

--- a/src/main/java/sopt/sopt36goodoc/global/exception/ErrorCode.java
+++ b/src/main/java/sopt/sopt36goodoc/global/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package sopt.sopt36goodoc.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getErrorCode();
+    String getMessage();
+}

--- a/src/main/java/sopt/sopt36goodoc/global/exception/GlobalErrorCode.java
+++ b/src/main/java/sopt/sopt36goodoc/global/exception/GlobalErrorCode.java
@@ -1,0 +1,49 @@
+package sopt.sopt36goodoc.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum GlobalErrorCode implements ErrorCode{
+    /**
+     * 200 : 요청 성공
+     */
+    SUCCESS(HttpStatus.OK, "SUCCESS", "요청에 성공했습니다."),
+    CREATED(HttpStatus.CREATED, "CREATED", "요청에 성공했으며 리소스가 정상적으로 생성되었습니다."),
+    ACCEPTED(HttpStatus.ACCEPTED, "ACCEPTED", "요청에 성공했으나 처리가 완료되지 않았습니다."),
+
+    /**
+     * 300 : 리다이렉션
+     */
+    SEE_OTHER(HttpStatus.SEE_OTHER, "REDIRECT", "다른 주소로 요청해주세요."),
+
+    /**
+     * 400 : 요청 실패
+     */
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "REQUEST_001", "잘못된 요청입니다."),
+    INVALID_USER(HttpStatus.FORBIDDEN,"REQUEST_002","권한이 없는 유저의 접근입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "REQUEST_003", "잘못된 접근입니다."),
+    NOT_SUPPORTED_URI_ERROR(HttpStatus.NOT_FOUND, "REQUEST_004", "지원하지 않는 URL입니다."),
+    NOT_SUPPORTED_METHOD_ERROR(HttpStatus.METHOD_NOT_ALLOWED, "REQUEST_005", "지원하지 않는 HTTP Method 요청입니다."),
+    NOT_SUPPORTED_MEDIA_TYPE_ERROR(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "REQUEST_006", "잘못된 미디어 타입입니다."),
+    INVALID_HEADER_VALUE(HttpStatus.UNAUTHORIZED, "REQUEST_007", "올바르지 않은 헤더값입니다."),
+
+    /**
+     * 500 : 응답 실패
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RESPONSE_001", "서버와의 연결에 실패했습니다."),
+    BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "RESPONSE_002", "다른 서버로부터 잘못된 응답이 수신되었습니다."),
+    INSUFFICIENT_STORAGE(HttpStatus.INSUFFICIENT_STORAGE, "RESPONSE_003", "서버의 용량이 부족해 요청에 실패했습니다."),
+    UNSUPPORTED_ENCODING(HttpStatus.INTERNAL_SERVER_ERROR, "RESPONSE_004", "지원하지 않는 인코딩입니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+
+    GlobalErrorCode(HttpStatus status, String errorCode, String message) {
+        this.status = status;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/sopt/sopt36goodoc/global/exception/GlobalErrorCode.java
+++ b/src/main/java/sopt/sopt36goodoc/global/exception/GlobalErrorCode.java
@@ -11,7 +11,6 @@ public enum GlobalErrorCode implements ErrorCode{
     SUCCESS(HttpStatus.OK, "SUCCESS", "요청에 성공했습니다."),
     CREATED(HttpStatus.CREATED, "CREATED", "요청에 성공했으며 리소스가 정상적으로 생성되었습니다."),
     ACCEPTED(HttpStatus.ACCEPTED, "ACCEPTED", "요청에 성공했으나 처리가 완료되지 않았습니다."),
-
     /**
      * 300 : 리다이렉션
      */
@@ -22,12 +21,9 @@ public enum GlobalErrorCode implements ErrorCode{
      */
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "REQUEST_001", "잘못된 요청입니다."),
     INVALID_USER(HttpStatus.FORBIDDEN,"REQUEST_002","권한이 없는 유저의 접근입니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "REQUEST_003", "잘못된 접근입니다."),
-    NOT_SUPPORTED_URI_ERROR(HttpStatus.NOT_FOUND, "REQUEST_004", "지원하지 않는 URL입니다."),
-    NOT_SUPPORTED_METHOD_ERROR(HttpStatus.METHOD_NOT_ALLOWED, "REQUEST_005", "지원하지 않는 HTTP Method 요청입니다."),
-    NOT_SUPPORTED_MEDIA_TYPE_ERROR(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "REQUEST_006", "잘못된 미디어 타입입니다."),
-    INVALID_HEADER_VALUE(HttpStatus.UNAUTHORIZED, "REQUEST_007", "올바르지 않은 헤더값입니다."),
-
+    NOT_SUPPORTED_URI_ERROR(HttpStatus.NOT_FOUND, "REQUEST_003", "지원하지 않는 URL입니다."),
+    NOT_SUPPORTED_METHOD_ERROR(HttpStatus.METHOD_NOT_ALLOWED, "REQUEST_004", "지원하지 않는 HTTP Method 요청입니다."),
+    NOT_SUPPORTED_MEDIA_TYPE_ERROR(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "REQUEST_005", "잘못된 미디어 타입입니다."),
     /**
      * 500 : 응답 실패
      */

--- a/src/main/java/sopt/sopt36goodoc/global/exception/GlobalException.java
+++ b/src/main/java/sopt/sopt36goodoc/global/exception/GlobalException.java
@@ -1,0 +1,7 @@
+package sopt.sopt36goodoc.global.exception;
+
+public class GlobalException extends CustomException{
+    public GlobalException(ErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/sopt/sopt36goodoc/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sopt/sopt36goodoc/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,125 @@
+package sopt.sopt36goodoc.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import sopt.sopt36goodoc.global.dto.ResponseDto;
+
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+    /**
+     * Custom Exception 전용 ExceptionHandler (@RequestBody)
+     */
+    @ExceptionHandler(CommonException.class)
+    public ResponseEntity<ResponseDto<Void>> applicationException(CommonException e) {
+        ErrorCode code = e.getCode();
+        logging(code);
+
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ResponseDto.fail(code));
+    }
+
+    /**
+     * 요청 데이터 Validation 전용 ExceptionHandler (@RequestBody)
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto<Void>> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+        return convert(GlobalErrorCode.VALIDATION_ERROR, extractErrorMessage(fieldErrors));
+    }
+
+    /**
+     * 요청 데이터 Validation 전용 ExceptionHandler (@ModelAttribute)
+     */
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ResponseDto<Void>> bindException(BindException e) {
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+        return convert(GlobalErrorCode.VALIDATION_ERROR, extractErrorMessage(fieldErrors));
+    }
+
+    private String extractErrorMessage(List<FieldError> fieldErrors) {
+        if (fieldErrors.size() == 1) {
+            return fieldErrors.get(0).getDefaultMessage();
+        }
+
+        StringBuffer buffer = new StringBuffer();
+        for (FieldError error : fieldErrors) {
+            buffer.append(error.getDefaultMessage()).append("\n");
+        }
+        return buffer.toString();
+    }
+
+    /**
+     * 존재하지 않는 Endpoint 전용 ExceptionHandler
+     */
+    @ExceptionHandler({NoHandlerFoundException.class, MethodArgumentTypeMismatchException.class})
+    public ResponseEntity<ResponseDto<Void>> noHandlerFoundException() {
+        return convert(GlobalErrorCode.NOT_SUPPORTED_URI_ERROR);
+    }
+
+    /**
+     * HTTP Request Method 오류 전용 ExceptionHandler
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ResponseDto<Void>> httpRequestMethodNotSupportedException() {
+        return convert(GlobalErrorCode.NOT_SUPPORTED_METHOD_ERROR);
+    }
+
+    /**
+     * MediaType 전용 ExceptionHandler
+     */
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ResponseDto<Void>> httpMediaTypeNotSupportedException() {
+        return convert(GlobalErrorCode.NOT_SUPPORTED_MEDIA_TYPE_ERROR);
+    }
+
+    /**
+     * HTTP Request Method 오류 전용 ExceptionHandler
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ResponseDto<Void>> accessDeniedException() {
+        return convert(GlobalErrorCode.INVALID_USER);
+    }
+
+    /**
+     * 내부 서버 오류 전용 ExceptionHandler
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ResponseDto<Void>> handleAnyException(RuntimeException e, HttpServletRequest request) {
+        log.warn(e.getMessage());
+        log.warn(request.toString());
+        return convert(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ResponseDto<Void>> convert(ErrorCode code) {
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ResponseDto.fail(code));
+    }
+
+    private ResponseEntity<ResponseDto<Void>> convert(ErrorCode code, String message) {
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ResponseDto.fail(code, message));
+    }
+
+    private void logging(ErrorCode code) {
+        log.warn("{} | {} | {}", code.getStatus(), code.getErrorCode(), code.getMessage());
+    }
+}

--- a/src/main/java/sopt/sopt36goodoc/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sopt/sopt36goodoc/global/exception/GlobalExceptionHandler.java
@@ -25,8 +25,8 @@ public class GlobalExceptionHandler {
     /**
      * Custom Exception 전용 ExceptionHandler (@RequestBody)
      */
-    @ExceptionHandler(CommonException.class)
-    public ResponseEntity<ResponseDto<Void>> applicationException(CommonException e) {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ResponseDto<Void>> applicationException(CustomException e) {
         ErrorCode code = e.getCode();
         logging(code);
 


### PR DESCRIPTION
# 💥 Work Description
- [x] 공통 예외처리 기능 추가
- [x] 공통 response Dto 추가

# ⚙️ ISSUE
- closed #3 


# 💡 변경사항
- [x] 전역 에러 코드 추가
- [x] 커스텀 예외 클래스 추가
- [x] 전역 예외 핸들러 추가
- [x] 공통 ResponseDto 추가
- [x] security관련 의존성 제거
- [x] 공통 도메인 속성을 위한 BaseEntity추가


# 🌱 PR Point
- security를 사용하는 부분이 없다 보니 의존성 제거를 하였고, testController를 통해 공통 예외 처리 test완료했습니다.


# 🔗 Reference
https://www.logicbig.com/tutorials/misc/jackson/json-include-non-absent.html